### PR TITLE
Add parameter for primer_scheme_version

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -12,7 +12,7 @@ include { ncov_tools } from './modules/ncov-tools.nf'
 
 workflow {
   
-  ch_primer_scheme_version = Channel.of('1.0')
+  ch_primer_scheme_version = Channel.of(params.primer_scheme_version)
   ch_primer_scheme_name = Channel.of('V1200')
   ch_ncov_tools_version = Channel.of('1.1')
   ch_run_name = Channel.of(params.run_name)

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 params {
   profile = false
   metadata = 'NO_FILE'
+  primer_scheme_version = '2.0'
 }
 
 profiles {


### PR DESCRIPTION
Fixes #9 

Add new parameter `--primer_scheme_version` with default value '2.0'. This will pull down [this release](https://github.com/BCCDC-PHL/artic-ncov2019/releases/tag/v2.0) of our [BCCDC-PHL/artic-ncov2019](https://github.com/BCCDC-PHL/artic-ncov2019) repo.
