### PR TITLE
Allow completeness threshold to be set as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,21 @@ The ncov2019-artic-nf output directory is passed as input to this pipeline using
 
 A `metadata.tsv` file may be optionally provided. If it is provided, it should follow the format as described in [the ncov-tools documentation](https://github.com/jts/ncov-tools#metadata-optional) 
 
+The `completeness_threshold` can optionally be modified. Its default value is the same as that of `ncov-tools`, `0.75`.
+
+In the command below, `[square brackets]` indicate optional parameters. `<angled brackets>` indicate a placeholder to be replaced by the user in a real pipeline invocation.
+
 ```
 nextflow run BCCDC-PHL/ncov-tools-nf \
   -profile conda \
   --cache ~/.conda/envs \
   --run_name <run_name> \
   --artic_analysis_dir <output/from/ncov2019-artic-nf> \
+  [--completeness_threshold <completeness_threshold>] \
+  [--metadata <metadata.tsv>] \
   --outdir <ncov-tools-output> \
-  [--metadata metadata.tsv]
 ```
 
 ## Caveats
-- We assume that the negative control sample is named starting with the letters `NEG`, and that
-  no other sample in the run starts with those letters.
+- We currently assume that the negative control sample is named starting with the letters `NEG`, and that
+  no other sample in the run starts with those letters. This is being addressed in [this issue](https://github.com/BCCDC-PHL/ncov-tools-nf/issues/6).

--- a/modules/ncov-tools.nf
+++ b/modules/ncov-tools.nf
@@ -101,7 +101,6 @@ process create_config_yaml {
   script:
   def metadata = metadata.name != 'NO_FILE' ? "metadata: \\\"{data_root}/metadata.tsv\\\"" : ''
   """
-  touch config.yml
   echo "data_root: ncov-tools-input" >> config.yaml
   echo "run_name: ${run_name}" >> config.yaml
   echo "negative_control_samples: [ \\"${negative_control_sample}\\" ]" >> config.yaml

--- a/modules/ncov-tools.nf
+++ b/modules/ncov-tools.nf
@@ -114,6 +114,7 @@ process create_config_yaml {
   echo "platform: illumina" >> config.yaml
   echo "bed_type: unique_amplicons" >> config.yaml
   echo "offset: 0" >> config.yaml
+  echo "completeness_threshold: ${params.completeness_threshold}" >> config.yaml
   echo "assign_lineages: true" >> config.yaml
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,6 +2,7 @@ params {
   profile = false
   metadata = 'NO_FILE'
   primer_scheme_version = '2.0'
+  completeness_threshold = 0.75
 }
 
 profiles {


### PR DESCRIPTION
Fixes #5 

Adds the parameter and command-line flag `--completeness_threshold` with default value `0.75`