### PR TITLE
Update ncov-tools environment

### DIFF
--- a/environments/ncov-tools-1.9.yml
+++ b/environments/ncov-tools-1.9.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake
+  - snakemake>=8.0.0
   - mafft
   - augur
   - pysam
@@ -27,7 +27,7 @@ dependencies:
   - icu
   - boost-cpp
   - usher
-  - pangolin=4.4
+  - pangolin
   - setuptools=81.0.0
   - pip:
       - dendropy>=4.4.0

--- a/environments/ncov-tools-1.9.yml
+++ b/environments/ncov-tools-1.9.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake>=8.0.0
+  - snakemake
   - mafft
   - augur
   - pysam

--- a/environments/ncov-tools-1.9.yml
+++ b/environments/ncov-tools-1.9.yml
@@ -1,4 +1,4 @@
-name: ncov-qc_test
+name: ncov-qc
 channels:
   - conda-forge
   - bioconda
@@ -7,12 +7,12 @@ dependencies:
   - mafft
   - augur
   - pysam
-  - r-base=3.6.3
-  - iqtree<2
-  - bioconductor-ggtree=2.0.0
+  - r-base
+  - iqtree
+  - bioconductor-ggtree
   - r-argparse
-  - r-patchwork=1.0.0
-  - r-ggforce=0.3.1
+  - r-patchwork
+  - r-ggforce
   - bedtools
   - samtools
   - parasail-python
@@ -22,17 +22,17 @@ dependencies:
   - poppler
   - gofasta
   - numpy
-  - biopython=1.77
+  - biopython
   - snpeff=5.0-0
-  - icu=68.1
-  - boost-cpp=1.74.0
+  - icu
+  - boost-cpp
   - usher
+  - pangolin=4.4
+  - setuptools=81.0.0
   - pip:
       - dendropy>=4.4.0
       - pyvcf3
       - ncov-parser
-      - git+https://github.com/cov-lineages/pangolin.git
-      - git+https://github.com/cov-lineages/pangolin-data.git
       - git+https://github.com/cov-lineages/constellations.git
       - git+https://github.com/cov-lineages/scorpio.git
       - git+https://github.com/jts/ncov-watch.git

--- a/environments/ncov-tools-1.9.yml
+++ b/environments/ncov-tools-1.9.yml
@@ -1,8 +1,7 @@
-name: ncov-qc
+name: ncov-qc_test
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - snakemake
   - mafft
@@ -18,11 +17,11 @@ dependencies:
   - samtools
   - parasail-python
   - newick_utils
-  - pip=19.3.1
+  - pip
   - minimap2
   - poppler
   - gofasta
-  - numpy=1.19.1
+  - numpy
   - biopython=1.77
   - snpeff=5.0-0
   - icu=68.1

--- a/modules/ncov-tools.nf
+++ b/modules/ncov-tools.nf
@@ -39,11 +39,6 @@ process download_ncov_tools {
   wget https://github.com/BCCDC-PHL/ncov-tools/archive/v${version}.tar.gz
   tar -xzf v${version}.tar.gz
   mv ncov-tools-${version} ncov-tools
-
-  # temporary work around for deprecation of srcdir() in snakemake > v8.0
-  # may be best to fix in forked BCCDC-PHL/ncov-tools + jts/ncov-tools
-  cd ncov-tools/workflow
-  sed -i 's/srcdir(/workflow.source_path(/g' Snakefile rules/*.smk
   """
 }
 

--- a/modules/ncov-tools.nf
+++ b/modules/ncov-tools.nf
@@ -39,6 +39,11 @@ process download_ncov_tools {
   wget https://github.com/BCCDC-PHL/ncov-tools/archive/v${version}.tar.gz
   tar -xzf v${version}.tar.gz
   mv ncov-tools-${version} ncov-tools
+
+  # temporary work around for deprecation of srcdir() in snakemake > v8.0
+  # may be best to fix in forked BCCDC-PHL/ncov-tools + jts/ncov-tools
+  cd ncov-tools/workflow
+  sed -i 's/srcdir(/workflow.source_path(/g' Snakefile rules/*.smk
   """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,13 +1,13 @@
 manifest {
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'
-  version = '1.9.1.2'
+  version = '1.9.2.1'
 }
 
 params {
   profile = false
   metadata = 'NO_FILE'
-  ncov_tools_version = '1.9.1'
+  ncov_tools_version = '1.9.2'
   primer_scheme_name = 'V1200'
   primer_scheme_version = '4.0'
   completeness_threshold = 0.75

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,7 +1,7 @@
 manifest {
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'
-  version = '1.9.1.1'
+  version = '1.9.1.2'
 }
 
 params {


### PR DESCRIPTION
- remove defaults channel
- remove pinned versions that no longer resolve
- add setuptools and pin version 81.0.0 to ensure pkg_resources is available for ncov-watch
Fixes #61  
